### PR TITLE
Refactoring

### DIFF
--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -36,6 +36,10 @@ SECRET_KEY = 'AWS_SECRET_ACCESS_KEY'
 NAME = 'krux-boto'
 
 # Defaults
+# GOTCHA: If this is a simple string-to-string dictionary, values are evaluated on compilation.
+# This may cause some serious hair pulling if the developer decides to change the environment variable and expect
+# krux-boto to pick it up. Thus, make this a string-to-function dictionary so the values are evaluated on method call
+# and get up-to-date value.
 DEFAULT = {
     'log_level': lambda: DEFAULT_LOG_LEVEL,
     'access_key': lambda: os.environ.get(ACCESS_KEY),

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -34,7 +34,14 @@ from krux.cli import get_parser, get_group
 ACCESS_KEY = 'AWS_ACCESS_KEY_ID'
 SECRET_KEY = 'AWS_SECRET_ACCESS_KEY'
 NAME = 'krux-boto'
-DEFAULT_REGION = 'us-east-1'
+
+# Defaults
+DEFAULT = {
+    'log_level': DEFAULT_LOG_LEVEL,
+    'access_key': os.environ.get(ACCESS_KEY),
+    'secret_key': os.environ.get(SECRET_KEY),
+    'region': 'us-east-1'
+}
 
 
 # Designed to be called from krux.cli, or programs inheriting from it
@@ -44,26 +51,26 @@ def add_boto_cli_arguments(parser):
 
     group.add_argument(
         '--boto-log-level',
-        default=DEFAULT_LOG_LEVEL,
+        default=DEFAULT['log_level'],
         choices=LEVELS.keys(),
         help='Verbosity of boto logging. (default: %(default)s)'
     )
 
     group.add_argument(
         '--boto-access-key',
-        default=os.environ.get(ACCESS_KEY),
+        default=DEFAULT['access_key'],
         help='AWS Access Key to use. Defaults to ENV[%s]' % ACCESS_KEY,
     )
 
     group.add_argument(
         '--boto-secret-key',
-        default=os.environ.get(SECRET_KEY),
+        default=DEFAULT['secret_key'],
         help='AWS Secret Key to use. Defaults to ENV[%s]' % SECRET_KEY,
     )
 
     group.add_argument(
         '--boto-region',
-        default=DEFAULT_REGION,
+        default=DEFAULT['region'],
         choices=[r.name for r in boto.ec2.regions()],
         help='EC2 Region to connect to. (default: %(default)s)',
     )
@@ -73,10 +80,10 @@ class Boto(object):
 
     def __init__(
         self,
-        log_level=DEFAULT_LOG_LEVEL,
-        access_key=os.environ.get(ACCESS_KEY),
-        secret_key=os.environ.get(SECRET_KEY),
-        region=DEFAULT_REGION,
+        log_level=DEFAULT['log_level'],
+        access_key=DEFAULT['access_key'],
+        secret_key=DEFAULT['secret_key'],
+        region=DEFAULT['region'],
         logger=None,
         stats=None,
     ):

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -90,9 +90,9 @@ class Boto(object):
 
         # Because we're wrapping boto directly, use ___ as a prefix for
         # all our variables, so we don't clash with anything public
-        self.___name = NAME
-        self.___logger = logger or get_logger(self.___name)
-        self.___stats = stats or get_stats(prefix=self.___name)
+        self._name = NAME
+        self._logger = logger or get_logger(self._name)
+        self._stats = stats or get_stats(prefix=self._name)
 
         # this has to be 'public', so callers can use it. It's unfortunately
         # near impossible to transparently wrap this, because the boto.config
@@ -116,13 +116,13 @@ class Boto(object):
 
         for env_var, val in credential_map.iteritems():
             if val is None or len(val) < 1:
-                self.___logger.debug('Passed boto credentials is empty. Falling back to environment variable %s', env_var)
+                self._logger.debug('Passed boto credentials is empty. Falling back to environment variable %s', env_var)
             else:
 
                 # this way we can tell what credentials are being used,
                 # without dumping the whole secret into the logs
                 pp_val = val[0:3] + '[...]' + val[-3:]
-                self.___logger.debug('Setting boto credential %s to %s', env_var, pp_val)
+                self._logger.debug('Setting boto credential %s to %s', env_var, pp_val)
 
                 os.environ[env_var] = val
 
@@ -134,7 +134,7 @@ class Boto(object):
             # $ FOO= ./myprog.py
             # It'll return an empty string, and we'd not catch it.
             if not os.environ.get(env_var, None):
-                self.___logger.info(
+                self._logger.info(
                     'Boto environment credential %s NOT explicitly set ' +
                     '-- boto will look for a .boto file somewhere', env_var
                 )
@@ -143,7 +143,7 @@ class Boto(object):
         get_logger('boto').setLevel(LEVELS[log_level])
 
         # access it via the object
-        self.___boto = boto
+        self._boto = boto
 
     def __getattr__(self, attr):
         """Proxies calls to ``boto.*`` methods."""
@@ -153,12 +153,12 @@ class Boto(object):
         # This also gives us hooks for future logging/timers/etc and
         # extended wrapping of things the attributes return if we so
         # choose.
-        self.___logger.debug('Calling wrapped boto attribute: %s', attr)
+        self._logger.debug('Calling wrapped boto attribute: %s', attr)
 
-        attr = getattr(self.___boto, attr)
+        attr = getattr(self._boto, attr)
 
         if callable(attr):
-            self.___logger.debug("Boto attribute '%s' is callable", attr)
+            self._logger.debug("Boto attribute '%s' is callable", attr)
 
             @wraps(attr)
             def wrapper(*args, **kwargs):

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -6,9 +6,10 @@
 #
 # Standard libraries
 #
+
 from __future__ import absolute_import
-from pprint     import pprint
-from functools  import wraps
+from pprint import pprint
+from functools import wraps
 
 import os
 
@@ -16,7 +17,6 @@ import os
 # Third party libraries
 #
 
-### The boto library
 import boto
 import boto.ec2
 import boto.utils
@@ -25,124 +25,130 @@ import boto.utils
 # Internal libraries
 #
 
-from krux.logging       import get_logger, LEVELS, DEFAULT_LOG_LEVEL
-from krux.stats         import get_stats
-from krux.cli           import get_parser, get_group
+from krux.logging import get_logger, LEVELS, DEFAULT_LOG_LEVEL
+from krux.stats import get_stats
+from krux.cli import get_parser, get_group
 
 
-### Constants
-ACCESS_KEY      = 'AWS_ACCESS_KEY_ID'
-SECRET_KEY      = 'AWS_SECRET_ACCESS_KEY'
-NAME            = 'krux-boto'
-DEFAULT_REGION  = 'us-east-1'
+# Constants
+ACCESS_KEY = 'AWS_ACCESS_KEY_ID'
+SECRET_KEY = 'AWS_SECRET_ACCESS_KEY'
+NAME = 'krux-boto'
+DEFAULT_REGION = 'us-east-1'
 
 
-### Designed to be called from krux.cli, or programs inheriting from it
+# Designed to be called from krux.cli, or programs inheriting from it
 def add_boto_cli_arguments(parser):
 
     group = get_group(parser, 'boto')
 
     group.add_argument(
         '--boto-log-level',
-        default = DEFAULT_LOG_LEVEL,
-        choices = LEVELS.keys(),
-        help    = 'Verbosity of boto logging. (default: %(default)s)'
+        default=DEFAULT_LOG_LEVEL,
+        choices=LEVELS.keys(),
+        help='Verbosity of boto logging. (default: %(default)s)'
     )
 
     group.add_argument(
         '--boto-access-key',
-        default = os.environ.get(ACCESS_KEY),
-        help    = 'AWS Access Key to use. Defaults to ENV[%s]' % ACCESS_KEY,
+        default=os.environ.get(ACCESS_KEY),
+        help='AWS Access Key to use. Defaults to ENV[%s]' % ACCESS_KEY,
     )
 
     group.add_argument(
         '--boto-secret-key',
-        default = os.environ.get(SECRET_KEY),
-        help    = 'AWS Secret Key to use. Defaults to ENV[%s]' % SECRET_KEY,
+        default=os.environ.get(SECRET_KEY),
+        help='AWS Secret Key to use. Defaults to ENV[%s]' % SECRET_KEY,
     )
 
     group.add_argument(
         '--boto-region',
-        default = DEFAULT_REGION,
-        choices = [r.name for r in boto.ec2.regions()],
-        help    = 'EC2 Region to connect to. (default: %(default)s)',
+        default=DEFAULT_REGION,
+        choices=[r.name for r in boto.ec2.regions()],
+        help='EC2 Region to connect to. (default: %(default)s)',
     )
 
 
 class Boto(object):
-    def __init__(self, logger = None, stats = None, parser = None):
 
-        ### Because we're wrapping boto directly, use ___ as a prefix for
-        ### all our variables, so we don't clash with anything public
-        self.___name   = NAME
+    def __init__(
+        self,
+        logger=None,
+        stats=None,
+        parser=None
+    ):
+
+        # Because we're wrapping boto directly, use ___ as a prefix for
+        # all our variables, so we don't clash with anything public
+        self.___name = NAME
         self.___logger = logger or get_logger(self.___name)
-        self.___stats  = stats  or get_stats( prefix      = self.___name)
-        self.___parser = parser or get_parser(description = self.___name)
+        self.___stats = stats or get_stats(prefix=self.___name)
+        self.___parser = parser or get_parser(description=self.___name)
 
-        ### in case we got some of the information via the CLI
-        self.___args    = self.___parser.parse_args()
+        # in case we got some of the information via the CLI
+        self.___args = self.___parser.parse_args()
 
-        ### this has to be 'public', so callers can use it. It's unfortunately
-        ### near impossible to transparently wrap this, because the boto.config
-        ### is initialized before we get here, and all the classes do a look up
-        ### at compile time. So overriding doesn't help.
-        ### Wrapping doesn't work cleanly, because we 1) would have to wrap
-        ### everything, including future features we can't know about yet, as
-        ### well as 2) poke into the guts of the implementation classes to figure
-        ### out connection strings etc. It's quite cumbersome.
-        ### So for now, we just store the region that was asked for, and let the
-        ### caller use it. See the sample app for a howto.
+        # this has to be 'public', so callers can use it. It's unfortunately
+        # near impossible to transparently wrap this, because the boto.config
+        # is initialized before we get here, and all the classes do a look up
+        # at compile time. So overriding doesn't help.
+        # Wrapping doesn't work cleanly, because we 1) would have to wrap
+        # everything, including future features we can't know about yet, as
+        # well as 2) poke into the guts of the implementation classes to figure
+        # out connection strings etc. It's quite cumbersome.
+        # So for now, we just store the region that was asked for, and let the
+        # caller use it. See the sample app for a howto.
         self.cli_region = self.___args.boto_region
 
-        ### if these are set, make sure we set the environment again
-        ### as well; that way the underlying boto calls will just DTRT
-        ### without the need to wrap all the functions.
+        # if these are set, make sure we set the environment again
+        # as well; that way the underlying boto calls will just DTRT
+        # without the need to wrap all the functions.
         credential_map = {
             'boto_access_key': ACCESS_KEY,
             'boto_secret_key': SECRET_KEY,
         }
 
         for name, env_var in credential_map.iteritems():
-            val = getattr( self.___args, name, None )
+            val = getattr(self.___args, name, None)
 
             if val is not None:
 
-                ### this way we can tell what credentials are being used,
-                ### without dumping the whole secret into the logs
+                # this way we can tell what credentials are being used,
+                # without dumping the whole secret into the logs
                 pp_val = val[0:3] + '[...]' + val[-3:] if len(val) else '<empty>'
                 self.___logger.debug(
                     'Setting boto credential %s to %s', env_var, pp_val
                 )
 
-                os.environ[ env_var ] = val
+                os.environ[env_var] = val
 
-            ### If at this point the environment variable is NOT set,
-            ### you didn't set it, and we didn't set it. At which point
-            ### boto will go off spelunking for .boto files or other
-            ### settings. Best be clear about this. Using 'if not' because
-            ### if you set it like this:
-            ### $ FOO= ./myprog.py
-            ### It'll return an empty string, and we'd not catch it.
-            if not os.environ.get( env_var, None ):
+            # If at this point the environment variable is NOT set,
+            # you didn't set it, and we didn't set it. At which point
+            # boto will go off spelunking for .boto files or other
+            # settings. Best be clear about this. Using 'if not' because
+            # if you set it like this:
+            # $ FOO= ./myprog.py
+            # It'll return an empty string, and we'd not catch it.
+            if not os.environ.get(env_var, None):
                 self.___logger.info(
                     'Boto environment credential %s NOT explicitly set ' +
                     '-- boto will look for a .boto file somewhere', env_var
                 )
 
-        ### This sets the log level for the underlying boto library
-        get_logger('boto').setLevel( LEVELS[ self.___args.boto_log_level ] )
+        # This sets the log level for the underlying boto library
+        get_logger('boto').setLevel(LEVELS[self.___args.boto_log_level])
 
-        ### access it via the object
+        # access it via the object
         self.___boto = boto
 
     def __getattr__(self, attr):
         """Proxies calls to ``boto.*`` methods."""
 
-        ### This way, we don't have to write: rv = Boto().boto.some_call
-        ### But can just write: rv = Boto().some_call
-        ### This also gives us hooks for future logging/timers/etc and
-        ### extended wrapping of things the attributes return if we so
-        ### choose.
+        # This way, we don't have to write: rv = Boto().boto.some_call
+        # But can just write: rv = Boto().some_call
+        # This also gives us hooks for future logging/timers/etc and
+        # extended wrapping of things the attributes return if we so
+        # choose.
         self.___logger.debug('Calling wrapped boto attribute: %s', attr)
 
         attr = getattr(self.___boto, attr)

--- a/krux_boto/cli.py
+++ b/krux_boto/cli.py
@@ -30,7 +30,10 @@ class Application(krux.cli.Application):
         super(Application, self).__init__(name=name)
 
         self.boto = Boto(
-            parser=self.parser,
+            log_level=self.args.boto_log_level,
+            access_key=self.args.boto_access_key,
+            secret_key=self.args.boto_secret_key,
+            region=self.args.boto_region,
             logger=self.logger,
             stats=self.stats,
         )

--- a/krux_boto/cli.py
+++ b/krux_boto/cli.py
@@ -22,34 +22,38 @@ import boto
 import krux.cli
 from krux_boto.boto import Boto, add_boto_cli_arguments, NAME
 
+
 class Application(krux.cli.Application):
 
-    def __init__(self, name = NAME):
-        ### Call to the superclass to bootstrap.
-        super(Application, self).__init__(name = name)
+    def __init__(self, name=NAME):
+        # Call to the superclass to bootstrap.
+        super(Application, self).__init__(name=name)
 
         self.boto = Boto(
-            parser = self.parser,
-            logger = self.logger,
-            stats  = self.stats,
+            parser=self.parser,
+            logger=self.logger,
+            stats=self.stats,
         )
 
     def add_cli_arguments(self, parser):
-
-        ### add the arguments for boto
+        # add the arguments for boto
         add_boto_cli_arguments(parser)
+
+    def run(self):
+        region = self.boto.ec2.get_region(self.boto.cli_region)
+        ec2 = self.boto.connect_ec2(region=region)
+
+        self.logger.warn('Connected to region: %s', region.name)
+        for r in ec2.get_all_regions():
+            self.logger.warn('Region: %s', r.name)
 
 
 def main():
-    app    = Application()
-    region = boto.ec2.get_region(app.boto.cli_region)
-    ec2    = app.boto.connect_ec2(region = region)
-
-    app.logger.warn('Connected to region: %s', region.name)
-    for r in ec2.get_all_regions():
-        app.logger.warn('Region: %s', r.name)
+    app = Application()
+    with app.context():
+        app.run()
 
 
-### Run the application stand alone
+# Run the application stand alone
 if __name__ == '__main__':
     main()

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -33,7 +33,7 @@ def get_instance_region():
     placed in. If the metadata service can't be contacted, return a generic
     default instead.
     """
-    ### TODO: XXX This shouldn't get called if we're not on EC2.
+    # TODO: XXX This shouldn't get called if we're not on EC2.
     zone = boto.utils.get_instance_metadata().get('placement', {}).get('availability-zone', None)
     if zone is None:
         get_logger('krux_boto').warn('get_instance_region failed to get the local instance region')

--- a/setup.py
+++ b/setup.py
@@ -2,43 +2,45 @@
 #
 # © 2014 Krux Digital, Inc.
 #
+
 """
 Package setup for krux-boto
 """
-######################
-# Standard Libraries #
-######################
+
+#
+# Standard libraries
+#
 from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.0.7'
+VERSION = '0.0.7'
 
 # URL to the repository on Github.
-REPO_URL     = 'https://github.com/krux/python-krux-boto'
+REPO_URL = 'https://github.com/krux/python-krux-boto'
 # Github will generate a tarball as long as you tag your releases, so don't
 # forget to tag!
 DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
 
 
 setup(
-    name             = 'krux-boto',
-    version          = VERSION,
-    author           = 'Jos Boumans',
-    author_email     = 'jos@krux.com',
-    description      = 'Library for interacting with boto built on krux-stdlib',
-    url              = REPO_URL,
-    download_url     = DOWNLOAD_URL,
-    license          = 'All Rights Reserved.',
-    packages         = find_packages(),
-    install_requires = [
+    name='krux-boto',
+    version=VERSION,
+    author='Jos Boumans',
+    author_email='jos@krux.com',
+    description='Library for interacting with boto built on krux-stdlib',
+    url=REPO_URL,
+    download_url=DOWNLOAD_URL,
+    license='All Rights Reserved.',
+    packages=find_packages(),
+    install_requires=[
         'boto',
         'krux-stdlib',
     ],
-    entry_points     = {
+    entry_points={
         'console_scripts': [
             'krux-boto-test = krux_boto.cli:main',
         ],
     },
-    test_suite       = 'test',
+    test_suite='test',
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
     version=VERSION,
     author='Jos Boumans',
     author_email='jos@krux.com',
+    maintainer='Peter Han',
+    maintainer_email='phan@krux.com',
     description='Library for interacting with boto built on krux-stdlib',
     url=REPO_URL,
     download_url=DOWNLOAD_URL,

--- a/test/boto_test.py
+++ b/test/boto_test.py
@@ -90,8 +90,8 @@ class BotoTest(unittest.TestCase):
         mock_logger = MagicMock(spec=Logger, autospec=True)
 
         credential_map = {
-            ACCESS_KEY: None,
-            SECRET_KEY: None,
+            ACCESS_KEY: '',
+            SECRET_KEY: '',
         }
 
         # Mocking the os.environ dictionary as an empty dictionary

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -60,7 +60,8 @@ class CliTest(unittest.TestCase):
         self.assertIn('boto_region', args)
         self.assertIn('boto_log_level', args)
 
-    def test_main(self):
+    @patch('krux_boto.cli.krux.cli.sys.exit')
+    def test_main(self, mock_exit):
         """
         Main method runs correctly
         """
@@ -78,3 +79,6 @@ class CliTest(unittest.TestCase):
         mock_logger.warn.assert_any_call('Connected to region: %s', 'us-east-1')
         for region in boto.connect_ec2().get_all_regions():
             mock_logger.warn.assert_any_call('Region: %s', region.name)
+
+        # Verify the mock sys.exit has been called
+        mock_exit.assert_called_once_with(0)


### PR DESCRIPTION
Massive overhauling of `krux-boto`.

1. Linted every file per PEP8.
2. Change the `cli.py` to make use of new `krux.cli.Application` features.
3. Change the `Boto` constructor to take arguments rather than a parser.
4. Set the defaults of arguments to match CLI arguments.