### PR TITLE
Fixing the credential problems introduced in version 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,108 +6,7 @@ Krux Python class built on top of [Krux Stdlib](https://staticfiles.krxd.net/fos
 CRITICAL NOTE about versions!
 -----------------------------
 
-Version 0.0.7 went through a major refactoring work and thus is not compatible with applications written with `krux-boto` version 0.0.6. The mechanism to fetch AWS credential is changed and may cause your application to use a different credentials than intended. Therefore, version 0.0.7 **should not be used**. Please use either 0.0.6 or 1.0.0 version.
-
-### Updating from 0.0.6 to 1.0.0
-
-In version 0.0.6, `krux_boto.Boto` object took an `argparse.ArgumentParser` object as an optional parameter for the constructor. This approach has been abandoned. `krux_boto.Boto` object now expects 4 parameters listed below. Therefore, following change is required to get your application working with version 1.0.0.
-
-```python
-
-# Version 0.0.6
-
-import krux.cli
-from krux_boto import Boto, add_boto_cli_arguments
-
-class Application(krux.cli.Application):
-
-    def __init__(self, name='krux-my-boto-script'):
-        super(Application, self).__init__(name=name)
-        
-        self.boto = Boto(
-            parser=self.parser,
-            logger=self.logger,
-            stats=self.stats,
-        )
-        
-    def add_cli_arguments(self, parser):
-        super(Application, self).add_cli_arguments(parser)
-        
-        add_boto_cli_arguments(parser)
-
-```
-```python
-
-# Version 1.0.0
-
-import krux.cli
-from krux_boto import Boto, add_boto_cli_arguments
-
-class Application(krux.cli.Application):
-
-    def __init__(self, name='krux-my-boto-script'):
-        super(Application, self).__init__(name=name)
-        
-        # Notice the change in constructor parameters
-        self.boto = Boto(
-            log_level=self.args.boto_log_level,
-            access_key=self.args.boto_access_key,
-            secret_key=self.args.boto_secret_key,
-            region=self.args.boto_region,
-            logger=self.logger,
-            stats=self.stats,
-        )
-        
-    def add_cli_arguments(self, parser):
-        super(Application, self).add_cli_arguments(parser)
-        
-        add_boto_cli_arguments(parser)
-
-```
-
-If you were not setting any of the optional parameters, use `krux_boto.Boto.get_boto()` function.
-
-```python
-
-# Version 0.0.6
-
-import krux.cli
-from krux_boto import Boto, add_boto_cli_arguments
-
-class Application(krux.cli.Application):
-
-    def __init__(self, name='krux-my-boto-script'):
-        super(Application, self).__init__(name=name)
-        
-        self.boto = Boto()
-        
-    def add_cli_arguments(self, parser):
-        super(Application, self).add_cli_arguments(parser)
-        
-        add_boto_cli_arguments(parser)
-
-```
-```python
-
-# Version 1.0.0
-
-import krux.cli
-from krux_boto import add_boto_cli_arguments, get_boto
-
-class Application(krux.cli.Application):
-
-    def __init__(self, name='krux-my-boto-script'):
-        super(Application, self).__init__(name=name)
-        
-        # Notice the change in constructor parameters
-        self.boto = get_boto()
-        
-    def add_cli_arguments(self, parser):
-        super(Application, self).add_cli_arguments(parser)
-        
-        add_boto_cli_arguments(parser)
-
-```
+Version 0.0.7 went through a major refactoring work and thus is not compatible with applications written with `krux-boto` version 0.0.6. The mechanism to fetch AWS credential is changed and may cause your application to use a different credentials than intended. Therefore, version 0.0.7 **should not be used**. Please use either 0.0.6 or 1.0.0 version. For update instructions, refer to the [section below](#version-update).
 
 Application quick start
 -----------------------
@@ -234,6 +133,52 @@ class MyApplication( object ):
 *NOTE:*
 * This info can also be found in `krux_boto.Boto.add_boto_cli_arguments`
 * All arguments are string
+
+### <a name="version-update"></a>Updating from 0.0.6 to 1.0.0
+
+In version 0.0.6, `krux_boto.Boto` object took an `argparse.ArgumentParser` object as an optional parameter for the constructor. This approach has been abandoned. `krux_boto.Boto` object now expects 4 parameters listed below. Therefore, following change is required to get your application working with version 1.0.0.
+
+```python
+
+# Version 0.0.6
+
+import krux.cli
+from krux_boto import Boto, add_boto_cli_arguments
+
+class Application(krux.cli.Application):
+
+    def __init__(self, name='krux-my-boto-script'):
+        super(Application, self).__init__(name=name)
+        
+        self.boto = Boto()
+        
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+        
+        add_boto_cli_arguments(parser)
+
+```
+```python
+
+# Version 1.0.0
+
+import krux.cli
+from krux_boto import add_boto_cli_arguments, get_boto
+
+class Application(krux.cli.Application):
+
+    def __init__(self, name='krux-my-boto-script'):
+        super(Application, self).__init__(name=name)
+        
+        # Notice the change in constructor parameters
+        self.boto = get_boto()
+        
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+        
+        add_boto_cli_arguments(parser)
+
+```
 
 Developing python-krux-boto
 ----------------------

--- a/README.md
+++ b/README.md
@@ -3,6 +3,112 @@ python-krux-boto
 
 Krux Python class built on top of [Krux Stdlib](https://staticfiles.krxd.net/foss/docs/pypi/krux-stdlib/) for interacting with [Boto](http://boto.readthedocs.org/en/latest/) and [Boto3](http://boto3.readthedocs.org/en/latest/index.html)
 
+CRITICAL NOTE about versions!
+-----------------------------
+
+Version 0.0.7 went through a major refactoring work and thus is not compatible with applications written with `krux-boto` version 0.0.6. The mechanism to fetch AWS credential is changed and may cause your application to use a different credentials than intended. Therefore, version 0.0.7 **should not be used**. Please use either 0.0.6 or 1.0.0 version.
+
+### Updating from 0.0.6 to 1.0.0
+
+In version 0.0.6, `krux_boto.Boto` object took an `argparse.ArgumentParser` object as an optional parameter for the constructor. This approach has been abandoned. `krux_boto.Boto` object now expects 4 parameters listed below. Therefore, following change is required to get your application working with version 1.0.0.
+
+```python
+
+# Version 0.0.6
+
+import krux.cli
+from krux_boto import Boto, add_boto_cli_arguments
+
+class Application(krux.cli.Application):
+
+    def __init__(self, name='krux-my-boto-script'):
+        super(Application, self).__init__(name=name)
+        
+        self.boto = Boto(
+            parser=self.parser,
+            logger=self.logger,
+            stats=self.stats,
+        )
+        
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+        
+        add_boto_cli_arguments(parser)
+
+```
+```python
+
+# Version 1.0.0
+
+import krux.cli
+from krux_boto import Boto, add_boto_cli_arguments
+
+class Application(krux.cli.Application):
+
+    def __init__(self, name='krux-my-boto-script'):
+        super(Application, self).__init__(name=name)
+        
+        # Notice the change in constructor parameters
+        self.boto = Boto(
+            log_level=self.args.boto_log_level,
+            access_key=self.args.boto_access_key,
+            secret_key=self.args.boto_secret_key,
+            region=self.args.boto_region,
+            logger=self.logger,
+            stats=self.stats,
+        )
+        
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+        
+        add_boto_cli_arguments(parser)
+
+```
+
+If you were not setting any of the optional parameters, use `krux_boto.Boto.get_boto()` function.
+
+```python
+
+# Version 0.0.6
+
+import krux.cli
+from krux_boto import Boto, add_boto_cli_arguments
+
+class Application(krux.cli.Application):
+
+    def __init__(self, name='krux-my-boto-script'):
+        super(Application, self).__init__(name=name)
+        
+        self.boto = Boto()
+        
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+        
+        add_boto_cli_arguments(parser)
+
+```
+```python
+
+# Version 1.0.0
+
+import krux.cli
+from krux_boto import add_boto_cli_arguments, get_boto
+
+class Application(krux.cli.Application):
+
+    def __init__(self, name='krux-my-boto-script'):
+        super(Application, self).__init__(name=name)
+        
+        # Notice the change in constructor parameters
+        self.boto = get_boto()
+        
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+        
+        add_boto_cli_arguments(parser)
+
+```
+
 Application quick start
 -----------------------
 

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -32,8 +32,6 @@ import boto.utils
 # Version3
 import boto3
 
-
-
 #
 # Internal libraries
 #
@@ -75,7 +73,7 @@ def get_boto(args=None, logger=None, stats=None):
     """
 
     if not args:
-        parser = get_parser()
+        parser = get_parser(description=NAME)
         add_boto_cli_arguments(parser)
         args = parser.parse_args()
 
@@ -94,6 +92,7 @@ def get_boto(args=None, logger=None, stats=None):
         stats=stats,
     )
 
+
 def get_boto3(args=None, logger=None, stats=None):
     """
     Return a usable Boto3 object without creating a class around it.
@@ -108,7 +107,7 @@ def get_boto3(args=None, logger=None, stats=None):
     """
 
     if not args:
-        parser = get_parser()
+        parser = get_parser(description=NAME)
         add_boto_cli_arguments(parser)
         args = parser.parse_args()
 
@@ -126,6 +125,7 @@ def get_boto3(args=None, logger=None, stats=None):
         logger=logger,
         stats=stats,
     )
+
 
 # Designed to be called from krux.cli, or programs inheriting from it
 def add_boto_cli_arguments(parser):
@@ -173,9 +173,7 @@ class BaseBoto(object):
         logger=None,
         stats=None,
     ):
-
-        # Because we're wrapping boto directly, use ___ as a prefix for
-        # all our variables, so we don't clash with anything public
+        # Private variables, not to be used outside this module
         self._name = NAME
         self._logger = logger or get_logger(self._name)
         self._stats = stats or get_stats(prefix=self._name)
@@ -191,6 +189,26 @@ class BaseBoto(object):
 
         if region is None:
             region = DEFAULT['region']()
+
+        # GOTCHA: Due to backward incompatible version change, the users of krux_boto may pass wrong credential
+        # Make sure the passed credential via CLI is the same as one passed into this instance
+        parser = get_parser(description=NAME)
+        add_boto_cli_arguments(parser)
+        args = parser.parse_args()
+        _access_key = getattr(args, 'boto_access_key', None)
+        _secret_key = getattr(args, 'boto_secret_key', None)
+        if _access_key is not None and _access_key != access_key:
+            self._logger.warn(
+                'You set %s as boto-access-key in CLI, but passed %s to the library. '
+                'Please check README to make sure you are passing the credentials correctly',
+                BaseBoto._hide_value(_access_key), BaseBoto._hide_value(access_key),
+            )
+        if _secret_key is not None and _secret_key != secret_key:
+            self._logger.warn(
+                'You set %s as boto-secret-key in CLI, but passed %s to the library. '
+                'Please check README to make sure you are passing the credentials correctly',
+                BaseBoto._hide_value(_secret_key), BaseBoto._hide_value(secret_key),
+            )
 
         # Infer the loglevel, but set it as a property so the subclasses can
         # use it to set the loglevels on the loghandlers for their implementation
@@ -223,8 +241,7 @@ class BaseBoto(object):
 
                 # this way we can tell what credentials are being used,
                 # without dumping the whole secret into the logs
-                pp_val = val[0:3] + '[...]' + val[-3:]
-                self._logger.debug('Setting boto credential %s to %s', env_var, pp_val)
+                self._logger.debug('Setting boto credential %s to %s', env_var, BaseBoto._hide_value(val))
 
                 os.environ[env_var] = val
 
@@ -240,6 +257,10 @@ class BaseBoto(object):
                     'Boto environment credential %s NOT explicitly set ' +
                     '-- boto will look for a .boto file somewhere', env_var
                 )
+
+    @staticmethod
+    def _hide_value(value):
+        return value[0:3] + '[...]' + value[-3:]
 
     def __getattr__(self, attr):
         """Proxies calls to ``boto.*`` methods."""

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -287,6 +287,7 @@ class BaseBoto(object):
 
         return attr
 
+
 class Boto(BaseBoto):
 
     # All the hard work is done in the superclass. We just need to use the
@@ -304,7 +305,7 @@ class Boto(BaseBoto):
         get_logger('boto').setLevel(self._boto_log_level)
 
 # Still inherit from BaseBoto, otherwise super().__init__ doesn't work
-#BaseBoto.register(Boto)
+# BaseBoto.register(Boto)
 
 
 class Boto3(BaseBoto):
@@ -335,4 +336,4 @@ class Boto3(BaseBoto):
         get_logger('botocore').setLevel(self._boto_log_level)
 
 # Still inherit from BaseBoto, otherwise super().__init__ doesn't work
-#BaseBoto.register(Boto3)
+# BaseBoto.register(Boto3)

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -190,7 +190,7 @@ class BaseBoto(object):
         if region is None:
             region = DEFAULT['region']()
 
-        # GOTCHA: Due to backward incompatible version change, the users of krux_boto may pass wrong credential
+        # GOTCHA: Due to backward incompatible version change in v1.0.0, the users of krux_boto may pass wrong credential
         # Make sure the passed credential via CLI is the same as one passed into this instance
         parser = get_parser(description=NAME)
         add_boto_cli_arguments(parser)
@@ -200,13 +200,15 @@ class BaseBoto(object):
         if _access_key is not None and _access_key != access_key:
             self._logger.warn(
                 'You set %s as boto-access-key in CLI, but passed %s to the library. '
-                'Please check README to make sure you are passing the credentials correctly',
+                'To avoid this error, consider using get_boto() function. '
+                'For more information, please check README.',
                 BaseBoto._hide_value(_access_key), BaseBoto._hide_value(access_key),
             )
         if _secret_key is not None and _secret_key != secret_key:
             self._logger.warn(
                 'You set %s as boto-secret-key in CLI, but passed %s to the library. '
-                'Please check README to make sure you are passing the credentials correctly',
+                'To avoid this error, consider using get_boto() function. '
+                'For more information, please check README.',
                 BaseBoto._hide_value(_secret_key), BaseBoto._hide_value(secret_key),
             )
 

--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -334,6 +334,3 @@ class Boto3(BaseBoto):
 
 # Still inherit from BaseBoto, otherwise super().__init__ doesn't work
 #BaseBoto.register(Boto3)
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.0.7'
+VERSION = '1.0.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'

--- a/test/boto_test.py
+++ b/test/boto_test.py
@@ -244,4 +244,3 @@ class BotoTest(unittest.TestCase):
 
         # Verify logging
         mock_logger.debug.assert_any_call('Calling wrapped boto attribute: %s on %s', 'client', self.boto)
-

--- a/test/boto_test.py
+++ b/test/boto_test.py
@@ -163,7 +163,10 @@ class BotoTest(unittest.TestCase):
                 )
 
         for key, value in credential_map.iteritems():
-            msg = 'You set %s as {0} in CLI, but passed %s to the library. Please check README to make sure you are passing the credentials correctly'.format(value['msg'])
+            msg = 'You set %s as {0} in CLI, but passed %s to the library. ' \
+                'To avoid this error, consider using get_boto() function. ' \
+                'For more information, please check README.' \
+                .format(value['msg'])
             cli_key = value['CLI'][0:3] + '[...]' + value['CLI'][-3:]
             env_key = value['ENV'][0:3] + '[...]' + value['ENV'][-3:]
             mock_logger.warn.assert_any_call(msg, cli_key, env_key)

--- a/test/boto_test.py
+++ b/test/boto_test.py
@@ -29,7 +29,7 @@ from mock import MagicMock, patch
 import krux_boto.boto
 import krux.cli
 import krux.logging
-from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments, ACCESS_KEY, SECRET_KEY
+from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments, ACCESS_KEY, SECRET_KEY, NAME
 
 
 class BotoTest(unittest.TestCase):
@@ -96,7 +96,6 @@ class BotoTest(unittest.TestCase):
 
         # Mocking the os.environ dictionary as an empty dictionary
         with patch.dict('krux_boto.boto.os.environ', clear=True):
-            print krux_boto.boto.os.environ
             self.boto = Boto(
                 access_key=credential_map[ACCESS_KEY],
                 secret_key=credential_map[SECRET_KEY],
@@ -109,13 +108,65 @@ class BotoTest(unittest.TestCase):
 
         # Verify the warning is logged
         for key, val in credential_map.iteritems():
-            print mock_logger.debug.call_args_list
             mock_logger.debug.assert_any_call('Passed boto credentials is empty. Falling back to environment variable %s', key)
             self.assertTrue(('Setting boto credential %s to %s', key, '<empty>') not in mock_logger.debug.call_args_list)
             mock_logger.info.assert_any_call(
                 'Boto environment credential %s NOT explicitly set -- boto will look for a .boto file somewhere',
                 key,
             )
+
+    def test_cli_arguments_check(self):
+        """
+        Boto warns users correctly when CLI arguments and passed in credentials don't match.
+        """
+        credential_map = {
+            ACCESS_KEY: {
+                'CLI': 'ZYXWVUTSR',
+                'ENV': 'ABCDEFGHI',
+                'msg': 'boto-access-key',
+            },
+            SECRET_KEY: {
+                'CLI': '0Z9Y8X7W6V5U4T3S2R1',
+                'ENV': '1A2B3C4D5E6F7G8H9I0',
+                'msg': 'boto-secret-key',
+            },
+        }
+
+        # Mocking the parser to trigger the warning
+        parser = krux.cli.get_parser(description=NAME)
+        add_boto_cli_arguments(parser)
+        namespace = parser.parse_args([
+            '--boto-access-key', credential_map[ACCESS_KEY]['CLI'],
+            '--boto-secret-key', credential_map[SECRET_KEY]['CLI'],
+        ])
+        mock_parser = MagicMock(
+            return_value=MagicMock(
+                spec=ArgumentParser,
+                autospec=True,
+                _action_groups=[],
+                parse_args=MagicMock(return_value=namespace)
+            )
+        )
+
+        # Mocking the logger to check for calls later
+        mock_logger = MagicMock(spec=Logger, autospec=True)
+
+        mock_env = {
+            ACCESS_KEY: credential_map[ACCESS_KEY]['ENV'],
+            SECRET_KEY: credential_map[SECRET_KEY]['ENV'],
+        }
+
+        with patch.dict('krux_boto.boto.os.environ', mock_env, clear=True):
+            with patch('krux_boto.boto.get_parser', mock_parser):
+                self.boto = Boto(
+                    logger=mock_logger
+                )
+
+        for key, value in credential_map.iteritems():
+            msg = 'You set %s as {0} in CLI, but passed %s to the library. Please check README to make sure you are passing the credentials correctly'.format(value['msg'])
+            cli_key = value['CLI'][0:3] + '[...]' + value['CLI'][-3:]
+            env_key = value['ENV'][0:3] + '[...]' + value['ENV'][-3:]
+            mock_logger.warn.assert_any_call(msg, cli_key, env_key)
 
     def test_logging_level(self):
         """


### PR DESCRIPTION
As a part of refactoring in version 0.0.7, a subtle bug was introduced that may cause the user of the library to use a wrong credential when using `krux_boto`. Thus, a warning is added to README and the code. An unit test specifically looking for this warning is added.

Because the change in version 0.0.7 breaks the backward compatibility, I am changing the major version to 1.