### PR TITLE
Credential check fix

### DIFF
--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -73,7 +73,7 @@ def get_boto(args=None, logger=None, stats=None):
     """
 
     if not args:
-        parser = get_parser(description=NAME)
+        parser = get_parser()
         add_boto_cli_arguments(parser)
         args = parser.parse_args()
 
@@ -107,7 +107,7 @@ def get_boto3(args=None, logger=None, stats=None):
     """
 
     if not args:
-        parser = get_parser(description=NAME)
+        parser = get_parser()
         add_boto_cli_arguments(parser)
         args = parser.parse_args()
 
@@ -192,9 +192,11 @@ class BaseBoto(object):
 
         # GOTCHA: Due to backward incompatible version change in v1.0.0, the users of krux_boto may pass wrong credential
         # Make sure the passed credential via CLI is the same as one passed into this instance
-        parser = get_parser(description=NAME)
+        parser = get_parser()
         add_boto_cli_arguments(parser)
-        args = parser.parse_args()
+        # GOTCHA: We only care about the credential arguments and nothing else.
+        # Don't validate the arguments or parse other things. Let krux.cli do that.
+        args = parser.parse_known_args()
         _access_key = getattr(args, 'boto_access_key', None)
         _secret_key = getattr(args, 'boto_secret_key', None)
         if _access_key is not None and _access_key != access_key:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'

--- a/test/boto_test.py
+++ b/test/boto_test.py
@@ -29,7 +29,7 @@ from mock import MagicMock, patch
 import krux_boto.boto
 import krux.cli
 import krux.logging
-from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments, ACCESS_KEY, SECRET_KEY, NAME
+from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments, ACCESS_KEY, SECRET_KEY
 
 
 class BotoTest(unittest.TestCase):
@@ -133,7 +133,7 @@ class BotoTest(unittest.TestCase):
         }
 
         # Mocking the parser to trigger the warning
-        parser = krux.cli.get_parser(description=NAME)
+        parser = krux.cli.get_parser()
         add_boto_cli_arguments(parser)
         namespace = parser.parse_args([
             '--boto-access-key', credential_map[ACCESS_KEY]['CLI'],
@@ -144,7 +144,7 @@ class BotoTest(unittest.TestCase):
                 spec=ArgumentParser,
                 autospec=True,
                 _action_groups=[],
-                parse_args=MagicMock(return_value=namespace)
+                parse_known_args=MagicMock(return_value=namespace)
             )
         )
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import
 import unittest
 from logging import Logger
+import sys
 
 #
 # Third party libraries
@@ -26,6 +27,7 @@ from mock import MagicMock, patch
 from krux.stats import DummyStatsClient
 from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments, NAME
 from krux_boto.cli import Application, main
+from krux.cli import get_group
 
 
 class CLItest(unittest.TestCase):
@@ -83,3 +85,35 @@ class CLItest(unittest.TestCase):
 
         # Verify the mock sys.exit has been called
         mock_exit.assert_called_once_with(0)
+
+    @patch.object(sys, 'argv', ['prog', 'arg1'])
+    def test_inheritance(self):
+        """
+        krux_boto.cli.Application can be inherited properly
+        """
+        app = TestApplication()
+
+        # Check that TestApplication inherits krux_boto.cli.Application
+        self.assertIsInstance(app.boto, Boto)
+
+        # Check the test CLI argument is handled correctly
+        self.assertIn('test', app.args)
+        self.assertEqual('arg1', app.args.test)
+
+
+class TestApplication(Application):
+
+    def __init__(self):
+        # Call to the superclass to bootstrap.
+        super(TestApplication, self).__init__(name='fake-unit-test-application')
+
+    def add_cli_arguments(self, parser):
+        super(TestApplication, self).add_cli_arguments(parser)
+
+        group = get_group(parser, self.name)
+
+        group.add_argument(
+            'test',
+            type=str,
+            help='Purely exists for the unit test',
+        )


### PR DESCRIPTION
In v1.0.0, a check to make sure the CLI boto credential arguments are correctly passed to `krux_boto` library was added. However, this was implemented wrongly so that it prevents other applications to add more CLI arguments on top of `krux_boto`. This PR addresses this.

1. The main bug is fixed.
1. The bug was partially caused by my misunderstanding of how `get_parser()` works. I have reverted my change regarding that function.
1. A unit test to check for this is added.