### PR TITLE
Upgrading krux-stdlib

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -16,36 +16,19 @@ boto3==1.2.3
 
 # From krux-stdlib
 pystache==0.5.4
-Sphinx==1.3.5
-Jinja2==2.8
-Pygments==2.1
-docutils==0.12
+Sphinx==1.2b1
+Jinja2==2.6
+Pygments==1.6
+docutils==0.10
 kruxstatsd==0.2.4
 statsd==2.0.3  # statsd is pegged at 2.0.3 by kruxstatsd
-argparse==1.4.0
-GitPython==1.0.2
-simplejson==3.8.1
-tornado==4.3
-lockfile==0.12.2
+argparse==1.2.1
+GitPython==0.3.2.RC1
+simplejson==3.3.0
+tornado==3.0.1
+lockfile==0.9.1
 subprocess32==3.2.7
-async==0.6.2
-fudge==1.1.0
-gitdb==0.6.4
-smmap==0.9.0
-
-# From pip --freeze
-Babel==2.2.0
-MarkupSafe==0.23
-alabaster==0.7.7
-backports-abc==0.4
-backports.ssl-match-hostname==3.5.0.1
-certifi==2015.11.20.1
-pbr==1.8.1
-pygerduty==0.32.1
-pytz==2015.7
-singledispatch==3.4.0.3
-six==1.10.0
-snowballstemmer==1.2.1
-sphinx-rtd-theme==0.1.9
-wheel==0.24.0
-wsgiref==0.1.2
+async==0.6.1
+fudge==1.0.3
+gitdb==0.5.4
+smmap==0.8.2

--- a/requirements.pip
+++ b/requirements.pip
@@ -16,19 +16,36 @@ boto3==1.2.3
 
 # From krux-stdlib
 pystache==0.5.4
-Sphinx==1.2b1
-Jinja2==2.6
-Pygments==1.6
-docutils==0.10
+Sphinx==1.3.5
+Jinja2==2.8
+Pygments==2.1
+docutils==0.12
 kruxstatsd==0.2.4
 statsd==2.0.3  # statsd is pegged at 2.0.3 by kruxstatsd
-argparse==1.2.1
-GitPython==0.3.2.RC1
-simplejson==3.3.0
-tornado==3.0.1
-lockfile==0.9.1
+argparse==1.4.0
+GitPython==1.0.2
+simplejson==3.8.1
+tornado==4.3
+lockfile==0.12.2
 subprocess32==3.2.7
-async==0.6.1
-fudge==1.0.3
-gitdb==0.5.4
-smmap==0.8.2
+async==0.6.2
+fudge==1.1.0
+gitdb==0.6.4
+smmap==0.9.0
+
+# From pip --freeze
+Babel==2.2.0
+MarkupSafe==0.23
+alabaster==0.7.7
+backports-abc==0.4
+backports.ssl-match-hostname==3.5.0.1
+certifi==2015.11.20.1
+pbr==1.8.1
+pygerduty==0.32.1
+pytz==2015.7
+singledispatch==3.4.0.3
+six==1.10.0
+snowballstemmer==1.2.1
+sphinx-rtd-theme==0.1.9
+wheel==0.24.0
+wsgiref==0.1.2

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux' standard library, which this is built on
-krux-stdlib==2.1.1
+krux-stdlib==2.2.1
 
 # The library this is wrapping
 boto==2.39.0
@@ -27,6 +27,7 @@ GitPython==1.0.2
 simplejson==3.8.1
 tornado==4.3
 lockfile==0.12.2
+subprocess32==3.2.7
 async==0.6.2
 fudge==1.1.0
 gitdb==0.6.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.0.2'
+VERSION = '1.0.3'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'


### PR DESCRIPTION
This is to get the bug fix from `krux-stdlib`. Refer to [this PR](https://github.com/krux/python-krux-stdlib/pull/36) for the bug details.