### PR TITLE
Requirements upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ cover/
 # Sphinx documentation
 docs/_build/
 
+# JetBrain IDE settings
+.idea/

--- a/dev-requirement.pip
+++ b/dev-requirement.pip
@@ -9,6 +9,9 @@ mock==2.0.0
 nose==1.3.7
 
 # Transitive libraries
+# This is needed so there are no version conflicts when
+# one downstream library does NOT specify the version it wants,
+# and another one does.
 
 # From mock
 funcsigs==1.0.2

--- a/dev-requirement.pip
+++ b/dev-requirement.pip
@@ -2,11 +2,10 @@
 -r requirements.pip
 
 # For unit tests
-# GOTCHA: Coverage is pegged at the latest version of 3, because of the error it throw when detemining
-# branch coverage.
-coverage==3.7.1
-# GOTCHA: This is the last version we can build in Jenkins due to the setuptools version limit.
-mock==1.1.2
+coverage==4.2
+# GOTCHA: Make sure this is installed with the latest version of pip. Without it, you will run into following error:
+# `error in setup command: Error parsing /data/jenkins/workspace/python-krux-boto-pull-request/.ci.virtualenv/build/mock/setup.cfg: SyntaxError: '<' operator not allowed in environment markers`
+mock==2.0.0
 nose==1.3.7
 
 # Transitive libraries

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,13 +2,11 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux' standard library, which this is built on
-krux-stdlib==2.3.0
+krux-stdlib==2.4.0
 
 # The library this is wrapping
 boto==2.42.0
-# Boto3 is out now as well, and we want to offer access to both
 boto3==1.4.0
-botocore==1.4.49
 
 # For RegionCode enum
 enum34==1.1.6
@@ -20,27 +18,31 @@ enum34==1.1.6
 
 # From krux-stdlib
 pystache==0.5.4
-Sphinx==1.2b1
-Jinja2==2.6
-Pygments==1.6
-docutils==0.10
-kruxstatsd==0.2.4
-statsd==2.0.3  # statsd is pegged at 2.0.3 by kruxstatsd
-argparse==1.2.1
-GitPython==0.3.2.RC1
-simplejson==3.3.0
+Sphinx==1.4.6
+kruxstatsd==0.3.0
+argparse==1.4.0
 tornado==3.0.1
-lockfile==0.9.1
+simplejson==3.8.2
+GitPython==2.0.8
+lockfile==0.12.2
 subprocess32==3.2.7
-async==0.6.1
-fudge==1.0.3
-gitdb==0.5.4
-smmap==0.8.2
+Jinja2==2.8
+MarkupSafe==0.23
+Pygments==2.1.3
+alabaster==0.7.9
+babel==2.3.4
+docutils==0.12
+imagesize==0.7.1
+pytz==2016.6.1
+six==1.10.0
+snowballstemmer==1.2.1
+statsd==3.2.1
+gitdb==0.6.4
+smmap==0.9.0
 
-# From pip --freeze
+# From boto3
+botocore==1.4.58
 futures==3.0.5
 jmespath==0.9.0
-pygerduty==0.35.1
 python-dateutil==2.5.3
-s3transfer==0.1.2
-six==1.10.0
+s3transfer==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,15 @@ setup(
     license='All Rights Reserved.',
     packages=find_packages(),
     install_requires=[
+        'krux-stdlib',
         'boto',
         'boto3',
-        'krux-stdlib',
+        'enum34',
+    ],
+    tests_require=[
+        'coverage',
+        'mock',
+        'nose',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## What does this PR do?
This PR upgrades the requirements to the latest versions and cleans up `setup.py`.

## Why is this change being made?
#24 introduced a bug that `enum34` is not included in `setup.py`. And a new version of [`krux-stdlib`](https://github.com/krux/python-krux-stdlib) is out.

## Where should the reviewer start?
`requirements.pip`

## How was this tested? How can the reviewer verify your testing?
The change was manually tested on the development environment and through the unit test.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] Dependencies have been documented, deployed, and verified as
      appropriate.