### PR TITLE
Use six.iteritems() for Python 3 compatibility

### DIFF
--- a/krux_boto/boto.py
+++ b/krux_boto/boto.py
@@ -31,6 +31,8 @@ import boto.utils
 # Version3
 import boto3
 
+from six import iteritems
+
 #
 # Internal libraries
 #
@@ -142,13 +144,13 @@ def add_boto_cli_arguments(parser):
     group.add_argument(
         '--boto-access-key',
         default=DEFAULT['access_key'](),
-        help='AWS Access Key to use. Defaults to ENV[%s]' % ACCESS_KEY,
+        help='AWS Access Key to use. Defaults to ENV[{0}]'.format(ACCESS_KEY)
     )
 
     group.add_argument(
         '--boto-secret-key',
         default=DEFAULT['secret_key'](),
-        help='AWS Secret Key to use. Defaults to ENV[%s]' % SECRET_KEY,
+        help='AWS Secret Key to use. Defaults to ENV[{0}]'.format(SECRET_KEY),
     )
 
     group.add_argument(
@@ -238,7 +240,7 @@ class BaseBoto(object):
             SECRET_KEY: secret_key,
         }
 
-        for env_var, val in credential_map.iteritems():
+        for env_var, val in iteritems(credential_map):
             if val is None or len(val) < 1:
                 self._logger.debug('Passed boto credentials is empty. Falling back to environment variable %s', env_var)
             else:
@@ -335,6 +337,7 @@ class Boto(BaseBoto):
                 regions.append(region.name)
 
         return regions
+
 
 class Boto3(BaseBoto):
 

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -17,6 +17,7 @@ from collections import Mapping
 
 import boto.utils
 from enum import Enum
+from six import iteritems
 
 #
 # Internal libraries
@@ -99,7 +100,7 @@ class __RegionCode(Mapping):
         #       Thus, we cannot handle the difference of underscore and dash gracefully.
         #       However, since __getitem__() is merely a lookup of _member_map_ dictionary, duplicate the elements
         #       in the private dictionary so that we can handle AWS region <-> RegionCode.Region conversion smoothly.
-        for name, region in self.Region._member_map_.iteritems():
+        for name, region in iteritems(self.Region._member_map_):
             self.Region._member_map_[name.lower().replace('_', '-')] = region
 
     def __iter__(self):

--- a/requirements.pip
+++ b/requirements.pip
@@ -11,6 +11,9 @@ boto3==1.4.0
 # For RegionCode enum
 enum34==1.1.6
 
+# For Python 3 compabitility
+six==1.10.0
+
 # Transitive libraries
 # This is needed so there are no version conflicts when
 # one downstream library does NOT specify the version it wants,
@@ -34,7 +37,6 @@ babel==2.3.4
 docutils==0.12
 imagesize==0.7.1
 pytz==2016.6.1
-six==1.10.0
 snowballstemmer==1.2.1
 statsd==3.2.1
 gitdb==0.6.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.1.0'
+VERSION = '1.2.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'
@@ -40,6 +40,7 @@ setup(
         'boto',
         'boto3',
         'enum34',
+        'six',
     ],
     tests_require=[
         'coverage',

--- a/test/boto_test.py
+++ b/test/boto_test.py
@@ -9,7 +9,6 @@
 
 from __future__ import absolute_import
 import unittest
-import os
 from logging import Logger, INFO
 
 #
@@ -17,10 +16,9 @@ from logging import Logger, INFO
 #
 
 import boto
-import boto3
-
 from argparse import ArgumentParser
 from mock import MagicMock, patch
+from six import iteritems
 
 #
 # Internal libraries
@@ -72,7 +70,7 @@ class BotoTest(unittest.TestCase):
             self.assertEqual(credential_map[SECRET_KEY], krux_boto.boto.os.environ[SECRET_KEY])
 
         # Verify logging
-        for key, val in credential_map.iteritems():
+        for key, val in iteritems(credential_map):
             self.assertTrue(
                 ('Passed boto credentials is empty. Falling back to environment variable %s', key) not in mock_logger.debug.call_args_list
             )
@@ -107,7 +105,7 @@ class BotoTest(unittest.TestCase):
             self.assertNotIn(SECRET_KEY, krux_boto.boto.os.environ)
 
         # Verify the warning is logged
-        for key, val in credential_map.iteritems():
+        for key, val in iteritems(credential_map):
             mock_logger.debug.assert_any_call('Passed boto credentials is empty. Falling back to environment variable %s', key)
             self.assertTrue(('Setting boto credential %s to %s', key, '<empty>') not in mock_logger.debug.call_args_list)
             mock_logger.info.assert_any_call(
@@ -162,7 +160,7 @@ class BotoTest(unittest.TestCase):
                     logger=mock_logger
                 )
 
-        for key, value in credential_map.iteritems():
+        for key, value in iteritems(credential_map):
             msg = 'You set %s as {0} in CLI, but passed %s to the library. ' \
                 'To avoid this error, consider using get_boto() function. ' \
                 'For more information, please check README.' \

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -15,8 +15,8 @@ from logging import Logger
 # Third party libraries
 #
 
-import boto
 from mock import MagicMock, patch
+from six import iteritems
 
 #
 # Internal libraries
@@ -101,7 +101,7 @@ class RegionCodeTest(unittest.TestCase):
         """
         RegionCode.__iter__() is correctly set up and iterates through the dictionary.
         """
-        for key, value in RegionCode.iteritems():
+        for key, value in iteritems(RegionCode):
             self.assertEquals(self.REGIONS[key], value)
 
     def test_len(self):


### PR DESCRIPTION
## What does this PR do?
This PR updates all dictionary iterations to use `six.iteritems()` for Python 3 compatibility. It also includes minor code clean up and a minor version increment.

## Why is this change being made?
Since `krux-boto` is an open source library, it should be available for all version of Python.

## Where should the reviewer start?
From the top. Most changes are independent changes.

## How was this tested? How can the reviewer verify your testing?
This was tested manually in the development environment and through unit tests.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation has been updated.
- [x] Dependencies have been documented, deployed, and verified as
      appropriate.