### PR TITLE
Adding --version to krux_boto.cli.Application

### DIFF
--- a/krux_boto/__init__.py
+++ b/krux_boto/__init__.py
@@ -1,3 +1,1 @@
-from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments
-from krux_boto.cli import Application
-from krux_boto.util import Error, get_instance_region
+VERSION = '1.2.1'

--- a/krux_boto/__init__.py
+++ b/krux_boto/__init__.py
@@ -1,1 +1,4 @@
-VERSION = '1.2.1'
+# Deprecated: These import statements are deprecated and should be removed in v2 of krux-boto
+from krux_boto.boto import Boto, Boto3, add_boto_cli_arguments
+from krux_boto.cli import Application
+from krux_boto.util import Error, get_instance_region

--- a/krux_boto/cli.py
+++ b/krux_boto/cli.py
@@ -8,26 +8,27 @@
 #
 
 from __future__ import absolute_import
-from pprint import pprint
 
 #
 # Third party libraries
 #
-
-import boto
 
 #
 # Internal libraries
 #
 
 import krux.cli
+from krux_boto import VERSION
 from krux_boto.boto import add_boto_cli_arguments, get_boto, get_boto3, NAME
 from krux_boto.util import RegionCode
 
 
 class Application(krux.cli.Application):
 
-    def __init__(self, name=NAME):
+    def __init__(self, name=NAME, *args, **kwargs):
+
+        self._VERSIONS[NAME] = VERSION
+
         # Call to the superclass to bootstrap.
         super(Application, self).__init__(name=name)
 

--- a/krux_boto/cli.py
+++ b/krux_boto/cli.py
@@ -8,6 +8,7 @@
 #
 
 from __future__ import absolute_import
+import pkg_resources
 
 #
 # Third party libraries
@@ -18,16 +19,19 @@ from __future__ import absolute_import
 #
 
 import krux.cli
-from krux_boto import VERSION
 from krux_boto.boto import add_boto_cli_arguments, get_boto, get_boto3, NAME
 from krux_boto.util import RegionCode
 
 
 class Application(krux.cli.Application):
+    # XXX: Usually, a VERSION constant should be set in __init__.py and be imported.
+    #      However, krux-boto adds some basic classes to __init__.py and importing VERSION constant here
+    #      causes a dependency circle. Thus, set VERSION constant in setup.py as usual and import it
+    #      here using pkg_resources
+    _VERSION = pkg_resources.require('krux-boto')[0].version
 
     def __init__(self, name=NAME, *args, **kwargs):
-
-        self._VERSIONS[NAME] = VERSION
+        self._VERSIONS[NAME] = self._VERSION
 
         # Call to the superclass to bootstrap.
         super(Application, self).__init__(name=name)

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux' standard library, which this is built on
-krux-stdlib==2.5.0
+krux-stdlib==2.5.1
 
 # The library this is wrapping
 boto==2.42.0
@@ -22,7 +22,7 @@ six==1.10.0
 # From krux-stdlib
 pystache==0.5.4
 Sphinx==1.4.6
-kruxstatsd==0.3.0
+kruxstatsd==0.3.1
 argparse==1.4.0
 tornado==3.0.1
 simplejson==3.8.2

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@
 --extra-index-url https://staticfiles.krxd.net/foss/pypi/
 
 # Krux' standard library, which this is built on
-krux-stdlib==2.4.0
+krux-stdlib==2.5.0
 
 # The library this is wrapping
 boto==2.42.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.2.1'
+VERSION = '1.3.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ Package setup for krux-boto
 #
 from __future__ import absolute_import
 from setuptools import setup, find_packages
+from krux_boto import VERSION
 
-# We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.2.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'
 # Github will generate a tarball as long as you tag your releases, so don't
 # forget to tag!
+# We use the version to construct the DOWNLOAD_URL.
 DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,15 @@ Package setup for krux-boto
 #
 from __future__ import absolute_import
 from setuptools import setup, find_packages
-from krux_boto import VERSION
 
+
+# We use the version to construct the DOWNLOAD_URL.
+VERSION = '1.2.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'
 # Github will generate a tarball as long as you tag your releases, so don't
 # forget to tag!
-# We use the version to construct the DOWNLOAD_URL.
 DOWNLOAD_URL = ''.join((REPO_URL, '/tarball/release/', VERSION))
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 import unittest
 from logging import Logger
 import sys
+import pkg_resources
 
 #
 # Third party libraries
@@ -27,10 +28,10 @@ from krux_boto.boto import Boto, Boto3, NAME
 from krux_boto.cli import Application, main
 from krux.cli import get_group
 from krux_boto.util import RegionCode
-from krux_boto import VERSION
 
 
 class CLItest(unittest.TestCase):
+    _VERSION = pkg_resources.require('krux-boto')[0].version
 
     def test_init(self):
         """
@@ -50,7 +51,7 @@ class CLItest(unittest.TestCase):
 
         # Verify the version info is specified
         self.assertIn(NAME, self.app._VERSIONS)
-        self.assertEqual(VERSION, self.app._VERSIONS[NAME])
+        self.assertEqual(self._VERSION, self.app._VERSIONS[NAME])
 
     def test_add_cli_arguments(self):
         """

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -27,6 +27,7 @@ from krux_boto.boto import Boto, Boto3, NAME
 from krux_boto.cli import Application, main
 from krux.cli import get_group
 from krux_boto.util import RegionCode
+from krux_boto import VERSION
 
 
 class CLItest(unittest.TestCase):
@@ -46,6 +47,10 @@ class CLItest(unittest.TestCase):
 
         self.assertIsInstance(self.app.boto, Boto)
         self.assertIsInstance(self.app.boto3, Boto3)
+
+        # Verify the version info is specified
+        self.assertIn(NAME, self.app._VERSIONS)
+        self.assertEqual(VERSION, self.app._VERSIONS[NAME])
 
     def test_add_cli_arguments(self):
         """

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -22,8 +22,7 @@ from six import iteritems
 # Internal libraries
 #
 
-from krux_boto import get_instance_region, Error
-from krux_boto.util import RegionCode
+from krux_boto.util import RegionCode, get_instance_region, Error
 
 
 class UtilTest(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?
This PR adds `--version` CLI argument to `krux_boto.cli.Application`.

## Why is this change being made?
Let's add `--version` CLI argument to some of the most frequently used tools to quickly figure out the versions.

## How was this tested? How can the reviewer verify your testing?
The change was test manually in the development environment as well as via unit test.

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.