### PR TITLE
Host utility function

### DIFF
--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -43,6 +43,14 @@ def get_instance_region():
         raise Error('get_instance_region failed to get the local instance region')
     return zone.rstrip(string.lowercase)
 
+def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
+    """
+    Loop through hosts to check if krxd.net domain is present
+    """
+    for i in range(len(hosts)):
+        if hosts[i][-8:len(hosts[i])] not in accepted_domains:
+            hosts[i] += '.' + default
+    return hosts
 
 # Region codes
 class __RegionCode(Mapping):

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -48,7 +48,7 @@ def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
     Loop through hosts to check if krxd.net domain is present
     """
     for i in range(len(hosts)):
-        if hosts[i][-8:len(hosts[i])] not in accepted_domains:
+        if hosts[i][-8:] not in accepted_domains:
             hosts[i] += '.' + default
     return list(hosts)
 

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -50,7 +50,7 @@ def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
     for i in range(len(hosts)):
         if hosts[i][-8:len(hosts[i])] not in accepted_domains:
             hosts[i] += '.' + default
-    return hosts
+    return list(hosts)
 
 # Region codes
 class __RegionCode(Mapping):

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -69,6 +69,28 @@ class UtilTest(unittest.TestCase):
         # Verify a warning is thrown
         mock_logger.warn.assert_called_once_with('get_instance_region failed to get the local instance region')
 
+    def test_setup_host_with_no_domain(self):
+        """
+        setup_hosts correctly adds default domain to hosts with no domain
+        """
+        mock_host_list = ['ops-dev004', 'ops-dev003', 'ops-dev005']
+        self.assertEquals(map(lambda x: x + '.krxd.net', mock_host_list), setup_hosts(mock_host_list))
+
+    def test_setup_host_with_domain(self):
+        """
+        setup_hosts correctly skips hosts with domain already added
+        """
+        mock_host_list = ['ops-dev004.krxd.net', 'ops-dev003.krxd.net', 'ops-dev005.krxd.net']
+        appended_hosts = setup_hosts(mock_host_list)
+        self.assertEquals(mock_host_list, appended_hosts)
+
+    def test_setup_host_mixed_domains(self):
+        """
+        setup_hosts works correctly with hosts with and without domains
+        """
+        mock_host_list = ['ops-dev004', 'ops-dev003.krxd.net']
+        appended_hosts = setup_hosts(mock_host_list)
+        self.assertEquals(['ops-dev004.krxd.net', 'ops-dev003.krxd.net'], appended_hosts)
 
 class RegionCodeTest(unittest.TestCase):
     REGIONS = {


### PR DESCRIPTION
## What does this PR do?

This PR contains an added utility function to krux_boto that appends a domain name to a list of hosts. It defaults to 'krxd.net'

## Why is this change being made?

This change makes it easier for users to manage AWS instances. Many libraries that use boto need this functionality.

## How was this tested? How can the reviewer verify your testing?

We created 3 unit tests in the util_test file for our utility function. We also manually tested.

## Completion checklist

- [X] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [X] The change has unit & integration tests as appropriate.