### PR TITLE
Added hosts utility function

### DIFF
--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -43,6 +43,14 @@ def get_instance_region():
         raise Error('get_instance_region failed to get the local instance region')
     return zone.rstrip(string.lowercase)
 
+def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
+    """
+    Loop through hosts to check if krxd.net domain is present
+    """
+    for i in range(len(hosts)):
+        if hosts[i][-8:len(hosts[i])] not in accepted_domains:
+            hosts[i] += '.' + default
+    return hosts
 
 # Region codes
 class __RegionCode(Mapping):

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -55,7 +55,7 @@ def setup_hosts(hosts, accepted_domains, default):
     """
     new_hostnames = []
     for i in range(len(hosts)):
-        # Python 2.6 support
+        # len(hosts[i]) is there for Python 2.6 string slice support
         if any([hosts[i][-len(domain):len(hosts[i])] == domain for domain in accepted_domains]):
             new_hostnames.append(hosts[i])
         else:

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -48,7 +48,7 @@ def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
     Loop through hosts to check if krxd.net domain is present
     """
     for i in range(len(hosts)):
-        if hosts[i][-8:len(hosts[i])] not in accepted_domains:
+        if hosts[i][-8:] not in accepted_domains:
             hosts[i] += '.' + default
     return list(hosts)
 

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -45,12 +45,23 @@ def get_instance_region():
 
 def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
     """
-    Loop through hosts to check if krxd.net domain is present
+    Loop through hosts to check if the domain matches any in accepted_domains. If not, append default.
+    This function will return a new list.
+
+    :param hosts: A list of hostname strings
+    :param accepted_domains: A list of accepted domain strings
+    :param default: A default domain name string to be appended to the hostnames
+
+    :return: A list of modified host name strings
     """
+    new_hostnames = []
     for i in range(len(hosts)):
-        if hosts[i][-8:] not in accepted_domains:
-            hosts[i] += '.' + default
-    return list(hosts)
+        # Python 2.6 support
+        if hosts[i][-8:len(hosts[i])] not in accepted_domains:
+            new_hostnames.append(hosts[i] + '.' + default)
+        else:
+            new_hostnames.append(hosts[i])
+    return new_hostnames
 
 # Region codes
 class __RegionCode(Mapping):

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -25,7 +25,8 @@ from six import iteritems
 
 from krux.logging import get_logger
 
-DOMAIN = 'krxd.net'
+ACCEPTED_DOMAINS = ['krxd.net']
+DEFAULT_DOMAIN = 'krxd.net'
 
 class Error(Exception):
     pass
@@ -44,7 +45,7 @@ def get_instance_region():
         raise Error('get_instance_region failed to get the local instance region')
     return zone.rstrip(string.lowercase)
 
-def setup_hosts(hosts, accepted_domains=[DOMAIN], default=DOMAIN):
+def setup_hosts(hosts, accepted_domains=ACCEPTED_DOMAINS, default=DEFAULT_DOMAIN):
     """
     Loop through hosts to check if the domain matches any in accepted_domains. If not, append default.
     This function will return a new list.

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -50,7 +50,7 @@ def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
     for i in range(len(hosts)):
         if hosts[i][-8:len(hosts[i])] not in accepted_domains:
             hosts[i] += '.' + default
-    return hosts
+    return list(hosts)
 
 # Region codes
 class __RegionCode(Mapping):

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -25,9 +25,6 @@ from six import iteritems
 
 from krux.logging import get_logger
 
-ACCEPTED_DOMAINS = ['krxd.net']
-DEFAULT_DOMAIN = 'krxd.net'
-
 class Error(Exception):
     pass
 
@@ -45,7 +42,7 @@ def get_instance_region():
         raise Error('get_instance_region failed to get the local instance region')
     return zone.rstrip(string.lowercase)
 
-def setup_hosts(hosts, accepted_domains=ACCEPTED_DOMAINS, default=DEFAULT_DOMAIN):
+def setup_hosts(hosts, accepted_domains, default):
     """
     Loop through hosts to check if the domain matches any in accepted_domains. If not, append default.
     This function will return a new list.

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -25,6 +25,7 @@ from six import iteritems
 
 from krux.logging import get_logger
 
+DOMAIN = 'krxd.net'
 
 class Error(Exception):
     pass
@@ -43,7 +44,7 @@ def get_instance_region():
         raise Error('get_instance_region failed to get the local instance region')
     return zone.rstrip(string.lowercase)
 
-def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
+def setup_hosts(hosts, accepted_domains=[DOMAIN], default=DOMAIN):
     """
     Loop through hosts to check if the domain matches any in accepted_domains. If not, append default.
     This function will return a new list.
@@ -56,11 +57,10 @@ def setup_hosts(hosts, accepted_domains=['krxd.net'], default='krxd.net'):
     """
     new_hostnames = []
     for i in range(len(hosts)):
-        # Python 2.6 support
-        if hosts[i][-8:len(hosts[i])] not in accepted_domains:
-            new_hostnames.append(hosts[i] + '.' + default)
-        else:
+        if any([hosts[i][-len(domain):len(hosts[i])] == domain for domain in accepted_domains]):
             new_hostnames.append(hosts[i])
+        else:
+            new_hostnames.append(hosts[i] + '.' + default)
     return new_hostnames
 
 # Region codes

--- a/krux_boto/util.py
+++ b/krux_boto/util.py
@@ -57,6 +57,7 @@ def setup_hosts(hosts, accepted_domains=[DOMAIN], default=DOMAIN):
     """
     new_hostnames = []
     for i in range(len(hosts)):
+        # Python 2.6 support
         if any([hosts[i][-len(domain):len(hosts[i])] == domain for domain in accepted_domains]):
             new_hostnames.append(hosts[i])
         else:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '1.3.1'
+VERSION = '1.4.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-boto'

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -69,6 +69,28 @@ class UtilTest(unittest.TestCase):
         # Verify a warning is thrown
         mock_logger.warn.assert_called_once_with('get_instance_region failed to get the local instance region')
 
+    def test_setup_host_with_no_domain(self):
+        """
+        setup_hosts correctly adds default domain to hosts with no domain
+        """
+        mock_host_list = ['ops-dev004', 'ops-dev003', 'ops-dev005']
+        self.assertEquals(map(lambda x: x + '.krxd.net', mock_host_list), setup_hosts(mock_host_list))
+
+    def test_setup_host_with_domain(self):
+        """
+        setup_hosts correctly skips hosts with domain already added
+        """
+        mock_host_list = ['ops-dev004.krxd.net', 'ops-dev003.krxd.net', 'ops-dev005.krxd.net']
+        appended_hosts = setup_hosts(mock_host_list)
+        self.assertEquals(mock_host_list, appended_hosts)
+
+    def test_setup_host_mixed_domains(self):
+        """
+        setup_hosts works correctly with hosts with and without domains
+        """
+        mock_host_list = ['ops-dev004', 'ops-dev003.krxd.net']
+        appended_hosts = setup_hosts(mock_host_list)
+        self.assertEquals(['ops-dev004.krxd.net', 'ops-dev003.krxd.net'], appended_hosts)
 
 class RegionCodeTest(unittest.TestCase):
     REGIONS = {

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -73,37 +73,43 @@ class UtilTest(unittest.TestCase):
         """
         setup_hosts correctly adds default domain to hosts with no domain
         """
+        accepted_hosts = ['krux.com']
+        default_domain = 'krux.com'
         mock_host_list = ['ops-dev004', 'ops-dev003', 'ops-dev005']
-        appended_hosts = setup_hosts(mock_host_list)
-        self.assertEquals([s + '.krxd.net' for s in mock_host_list], appended_hosts)
+        appended_hosts = setup_hosts(mock_host_list, accepted_hosts, default_domain)
+        self.assertEquals([s + '.' + default_domain for s in mock_host_list], appended_hosts)
 
     def test_setup_host_with_domain(self):
         """
         setup_hosts correctly skips hosts with domain already added
         """
-        mock_host_list = ['ops-dev004.krxd.net', 'ops-dev003.krxd.net', 'ops-dev005.krxd.net']
-        appended_hosts = setup_hosts(mock_host_list)
+        accepted_hosts = ['krux.com']
+        default_domain = 'krux.com'
+        mock_host_list = ['ops-dev004.krux.com', 'ops-dev003.krux.com', 'ops-dev005.krux.com']
+        appended_hosts = setup_hosts(mock_host_list, accepted_hosts, default_domain)
         self.assertEquals(mock_host_list, appended_hosts)
 
     def test_setup_host_mixed_domains(self):
         """
         setup_hosts works correctly with hosts with and without domains
         """
-        mock_host_list_with = ['ops-dev003.krxd.net']
+        accepted_hosts = ['krux.com']
+        default_domain = 'krux.com'
+        mock_host_list_with = ['ops-dev003.krux.com']
         mock_host_list_without = ['ops-dev004']
-        appended_hosts = setup_hosts(mock_host_list_without + mock_host_list_with)
-        mock_appended_hosts = [s + '.krxd.net' for s in mock_host_list_without] + mock_host_list_with
+        appended_hosts = setup_hosts(mock_host_list_without + mock_host_list_with, accepted_hosts, default_domain)
+        mock_appended_hosts = [s + '.' + default_domain for s in mock_host_list_without] + mock_host_list_with
         self.assertEquals(mock_appended_hosts, appended_hosts)
 
     def test_setup_host_with_accepted_hosts(self):
         """
         setup_hosts works correctly with multiple accepted domains with varying length
         """
-        accepted_hosts = ['krxd.net', 'krxd.io']
-        default_domain = 'krxd.net'
-        mock_host_list_with = ['ops-dev003.krxd.net', 'ops-dev004.krxd.io']
+        accepted_hosts = ['krux.com', 'krux.io']
+        default_domain = 'krux.com'
+        mock_host_list_with = ['ops-dev003.krux.com', 'ops-dev004.krux.io']
         mock_host_list_without = ['ops-dev001', 'ops-dev002']
-        mock_appended_hosts = [s + '.krxd.net' for s in mock_host_list_without] + mock_host_list_with
+        mock_appended_hosts = [s + '.' + default_domain for s in mock_host_list_without] + mock_host_list_with
         appended_hosts = setup_hosts(mock_host_list_without + mock_host_list_with, accepted_hosts, default_domain)
         self.assertEquals(mock_appended_hosts, appended_hosts)
 

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -75,7 +75,7 @@ class UtilTest(unittest.TestCase):
         """
         mock_host_list = ['ops-dev004', 'ops-dev003', 'ops-dev005']
         appended_hosts = setup_hosts(mock_host_list)
-        self.assertEquals(['ops-dev004.krxd.net', 'ops-dev003.krxd.net', 'ops-dev005.krxd.net'], appended_hosts)
+        self.assertEquals([s + '.krxd.net' for s in mock_host_list], appended_hosts)
 
     def test_setup_host_with_domain(self):
         """
@@ -89,9 +89,11 @@ class UtilTest(unittest.TestCase):
         """
         setup_hosts works correctly with hosts with and without domains
         """
-        mock_host_list = ['ops-dev004', 'ops-dev003.krxd.net']
-        appended_hosts = setup_hosts(mock_host_list)
-        self.assertEquals(['ops-dev004.krxd.net', 'ops-dev003.krxd.net'], appended_hosts)
+        mock_host_list_with = ['ops-dev003.krxd.net']
+        mock_host_list_without = ['ops-dev004']
+        appended_hosts = setup_hosts(mock_host_list_without + mock_host_list_with)
+        mock_appended_hosts = [s + '.krxd.net' for s in mock_host_list_without] + mock_host_list_with
+        self.assertEquals(mock_appended_hosts, appended_hosts)
 
 class RegionCodeTest(unittest.TestCase):
     REGIONS = {

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -95,6 +95,18 @@ class UtilTest(unittest.TestCase):
         mock_appended_hosts = [s + '.krxd.net' for s in mock_host_list_without] + mock_host_list_with
         self.assertEquals(mock_appended_hosts, appended_hosts)
 
+    def test_setup_host_with_accepted_hosts(self):
+        """
+        setup_hosts works correctly with multiple accepted domains with varying length
+        """
+        accepted_hosts = ['krxd.net', 'krxd.io']
+        default_domain = 'krxd.net'
+        mock_host_list_with = ['ops-dev003.krxd.net', 'ops-dev004.krxd.io']
+        mock_host_list_without = ['ops-dev001', 'ops-dev002']
+        mock_appended_hosts = [s + '.krxd.net' for s in mock_host_list_without] + mock_host_list_with
+        appended_hosts = setup_hosts(mock_host_list_without + mock_host_list_with, accepted_hosts, default_domain)
+        self.assertEquals(mock_appended_hosts, appended_hosts)
+
 class RegionCodeTest(unittest.TestCase):
     REGIONS = {
         RegionCode.Code.ASH: RegionCode.Region.us_east_1,

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -74,7 +74,8 @@ class UtilTest(unittest.TestCase):
         setup_hosts correctly adds default domain to hosts with no domain
         """
         mock_host_list = ['ops-dev004', 'ops-dev003', 'ops-dev005']
-        self.assertEquals(map(lambda x: x + '.krxd.net', mock_host_list), setup_hosts(mock_host_list))
+        appended_hosts = setup_hosts(mock_host_list)
+        self.assertEquals(map(lambda x: x + '.krxd.net', mock_host_list), appended_hosts)
 
     def test_setup_host_with_domain(self):
         """

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -22,7 +22,7 @@ from six import iteritems
 # Internal libraries
 #
 
-from krux_boto.util import RegionCode, get_instance_region, Error
+from krux_boto.util import RegionCode, get_instance_region, Error, setup_hosts
 
 
 class UtilTest(unittest.TestCase):

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -75,7 +75,7 @@ class UtilTest(unittest.TestCase):
         """
         mock_host_list = ['ops-dev004', 'ops-dev003', 'ops-dev005']
         appended_hosts = setup_hosts(mock_host_list)
-        self.assertEquals(map(lambda x: x + '.krxd.net', mock_host_list), appended_hosts)
+        self.assertEquals(['ops-dev004.krxd.net', 'ops-dev003.krxd.net', 'ops-dev005.krxd.net'], appended_hosts)
 
     def test_setup_host_with_domain(self):
         """


### PR DESCRIPTION
## What does this PR do?

This PR contains an added utility function to krux_boto that appends a domain name to a list of hosts. It defaults to 'krxd.net'

## Why is this change being made?

This change makes it easier for users to manage AWS instances. Many libraries that use boto need this functionality.

## How was this tested? How can the reviewer verify your testing?

We created 3 unit tests in the util_test file for our utility function. We also manually tested.

## Completion checklist

- [X] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [X] The change has unit & integration tests as appropriate.